### PR TITLE
[capnproto] update for simpler buffer reuse enabled by capnp-v0.13.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "capnp"
-version = "0.13.3"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739fa606458e49df64116a3cda1bf711ada360ce714357674d0950ed2132a6a1"
+checksum = "4e76a319e55a4ef27c8c383215fa3160167bd8a883e8d27c0ecd57ed81bca2af"
 
 [[package]]
 name = "cast"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ flexbuffers = "0.1.1"
 ron = "0.6.0"
 abomonation = { git = "https://github.com/TimelyDataflow/abomonation" }
 abomonation_derive = "0.5.0"
-capnp = "0.13.3"
+capnp = "0.13.6"
 
 [dev-dependencies]
 criterion = "0.3.3"


### PR DESCRIPTION
After implementing #5, I realized that some simplifications were possible in capnproto-rust's API.
I implemented those simplifications in https://github.com/capnproto/capnproto-rust/commit/8257850c8ba5eace0d208316f8515a92895ff30f and released a new crate version.

This pull request updates the benchmark to take advantage of the new simpler API.
In particular, the allocator can just be borrowed by the message builder -- no need to move it around.