### PR TITLE
upgrade to capnp 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "capnp"
-version = "0.13.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e76a319e55a4ef27c8c383215fa3160167bd8a883e8d27c0ecd57ed81bca2af"
+checksum = "ee33f13b9419d35f9ae6e0ee2e5ef6bd059a4d0da2fda16a88ddaf57dfe9acca"
 
 [[package]]
 name = "cast"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ flexbuffers = "0.1.1"
 ron = "0.6.0"
 abomonation = { git = "https://github.com/TimelyDataflow/abomonation" }
 abomonation_derive = "0.5.0"
-capnp = "0.13.6"
+capnp = "0.14.0"
 simd-json = "0.3.22"
 simd-json-derive = "0.1.15"
 prost = "0.6"

--- a/storeddata_capnp.rs
+++ b/storeddata_capnp.rs
@@ -141,7 +141,7 @@ pub mod stored_data {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder<Builder<'a>> for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
         fn set_pointer_builder<'b>(
             pointer: ::capnp::private::layout::PointerBuilder<'b>,
             value: Reader<'a>,
@@ -407,7 +407,7 @@ pub mod stored_data {
             }
         }
 
-        impl<'a> ::capnp::traits::SetPointerBuilder<Builder<'a>> for Reader<'a> {
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
             fn set_pointer_builder<'b>(
                 pointer: ::capnp::private::layout::PointerBuilder<'b>,
                 value: Reader<'a>,
@@ -629,7 +629,7 @@ pub mod stored_data {
             }
         }
 
-        impl<'a> ::capnp::traits::SetPointerBuilder<Builder<'a>> for Reader<'a> {
+        impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
             fn set_pointer_builder<'b>(
                 pointer: ::capnp::private::layout::PointerBuilder<'b>,
                 value: Reader<'a>,
@@ -819,7 +819,7 @@ pub mod range {
         }
     }
 
-    impl<'a> ::capnp::traits::SetPointerBuilder<Builder<'a>> for Reader<'a> {
+    impl<'a> ::capnp::traits::SetPointerBuilder for Reader<'a> {
         fn set_pointer_builder<'b>(
             pointer: ::capnp::private::layout::PointerBuilder<'b>,
             value: Reader<'a>,


### PR DESCRIPTION
Upgrades the capnp version to today's release, 0.14.0, and updates storeddata_capnp.rs to account for the removal of the `To` type parameter from the `SetPointerBuilder` trait.
