### PR TITLE
Add minicbor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,12 +459,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
@@ -504,12 +498,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown 0.9.1",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -585,6 +579,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "minicbor"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e65793a7836177614428b01e00d7089af2f308e8ad2fae92f324b2ee3c5d3bd9"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f79d5d3fb4f93c77ef7b97065fb65efe6abe670795ad8bc5be9c0e12005290"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1101,6 +1115,7 @@ dependencies = [
  "criterion",
  "flatbuffers",
  "flexbuffers",
+ "minicbor",
  "postcard",
  "prost",
  "prost-build",
@@ -1108,7 +1123,6 @@ dependencies = [
  "rmp-serde",
  "ron",
  "serde",
- "serde_cbor",
  "serde_json",
  "serde_yaml",
  "simd-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ bincode = "1.3.1"
 flatbuffers = "0.6.1"
 rmp-serde = "0.15.5"
 postcard = "0.7.0"
-serde_cbor = "0.11.1"
 serde_yaml = "0.8.13"
 flexbuffers = "2.0.0"
 ron = "0.6.0"
@@ -25,6 +24,7 @@ simd-json-derive = "0.2.2"
 prost = "0.8"
 rkyv = { version = "0.7.1", features = ["validation"] }
 bytecheck = { version = "0.6.1" }
+minicbor = {version = "0.12.0", features = ["std", "derive"]}
 
 [build-dependencies]
 prost-build = { version = "0.8" }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -367,6 +367,11 @@ fn compare_serde(c: &mut Criterion) {
         })
     });
     println!("proto3: {} bytes", buffer.len());
+    group.bench_function("de.proto3", |b| {
+        b.iter(|| {
+            proto3::StoredData::decode(black_box(black_box(buffer.as_slice()))).unwrap();
+        })
+    });
 
     group.bench_function("sr.abomonation", |b| {
         b.iter(|| {


### PR DESCRIPTION
As per the notice, [serde_json is an archived project](https://github.com/pyfisch/cbor). This PR replaces `serde_cbor` with `minicbor`. There is a drastic improvement in the benchmarks. Cbor is now one of the best options

I also tried `ciborium` but it gave worse performance, so chose `minicbor` instead 

I didn't update the README, as I don't know if the published results come always from the same environment