### PR TITLE
use new read_message_from_flat_slice_no_alloc() function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,9 +157,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "capnp"
-version = "0.14.0"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee33f13b9419d35f9ae6e0ee2e5ef6bd059a4d0da2fda16a88ddaf57dfe9acca"
+checksum = "e94e1364fccd72a72985acce20e240d419935e2debf0b004fd8821ce3720e2f4"
 
 [[package]]
 name = "cast"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ flexbuffers = "2.0.0"
 ron = "0.6.0"
 abomonation = { git = "https://github.com/TimelyDataflow/abomonation" }
 abomonation_derive = "0.5.0"
-capnp = "0.14.0"
+capnp = "0.14.7"
 simd-json = "0.4.6"
 simd-json-derive = "0.2.2"
 prost = "0.8"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -260,7 +260,7 @@ fn compare_serde(c: &mut Criterion) {
     println!("capnproto.unpacked: {} bytes", buffer.len());
     group.bench_function("de.capnproto.unpacked", |b| {
         b.iter(|| {
-            let message_reader = capnp::serialize::read_message_from_flat_slice(
+            let message_reader = capnp::serialize::read_message_from_flat_slice_no_alloc(
                 &mut black_box(buffer.as_slice()),
                 Default::default(),
             )


### PR DESCRIPTION
This makes de.capnproto.unpacked go about 20% faster.